### PR TITLE
removed additional "

### DIFF
--- a/timezone/make_time_zone_php_code.pl
+++ b/timezone/make_time_zone_php_code.pl
@@ -29,7 +29,7 @@ while ($str = <FILE>) {
   if ($region ne "") {
     print "  case " . qq(") . $region . qq(") . ":\n  ";
   }
-  print qq(    \$timezone = ") . $timezone . qq(") . ";\n";
+  print qq(    \$timezone = ) . $timezone  . ";\n";
   if ($region ne "") {
     print "      break;\n";
   } else {


### PR DESCRIPTION
just open this file using a text editor: http://www.maxmind.com/timezone.txt
...
ID,39,"Asia/Jayapura"
...
IR,,"Asia/Tehran"
IS,,"Atlantic/Reykjavik"
...
US,NY,"America/New_York"
...

it have quotation marks in start and end of TimeZone column, there is no need to add additional ones like these: 
...
ID,39,""Asia/Jayapura""
...
IR,,""Asia/Tehran""
IS,,""Atlantic/Reykjavik""
...
US,NY,""America/New_York""
...
