### PR TITLE
Remove die calls, add source description to error messages.

### DIFF
--- a/src/geoip.inc
+++ b/src/geoip.inc
@@ -1532,7 +1532,7 @@ function geoip_open($filename, $flags)
     if ($gi->flags & GEOIP_SHARED_MEMORY) {
         $gi->shmid = @shmop_open(GEOIP_SHM_KEY, "a", 0, 0);
     } else {
-        $gi->filehandle = fopen($filename, "rb") or die("Can not open $filename\n");
+        $gi->filehandle = fopen($filename, "rb") or trigger_error("GeoIP API: Can not open $filename\n", E_USER_ERROR);
         if ($gi->flags & GEOIP_MEMORY_CACHE) {
             $s_array = fstat($gi->filehandle);
             $gi->memory_buffer = fread($gi->filehandle, $s_array['size']);
@@ -1693,7 +1693,7 @@ function _geoip_seek_country_v6($gi, $ipnum)
             );
         } else {
             fseek($gi->filehandle, 2 * $gi->record_length * $offset, SEEK_SET) == 0
-            or die("fseek failed");
+            or trigger_error("GeoIP API: fseek failed", E_USER_ERROR);
             $buf = fread($gi->filehandle, 2 * $gi->record_length);
         }
         $x = array(0, 0);
@@ -1718,7 +1718,7 @@ function _geoip_seek_country_v6($gi, $ipnum)
             $offset = $x[0];
         }
     }
-    trigger_error("error traversing database - perhaps it is corrupt?", E_USER_ERROR);
+    trigger_error("GeoIP API: Error traversing database - perhaps it is corrupt?", E_USER_ERROR);
     return false;
 }
 
@@ -1740,7 +1740,7 @@ function _geoip_seek_country($gi, $ipnum)
             );
         } else {
             fseek($gi->filehandle, 2 * $gi->record_length * $offset, SEEK_SET) == 0
-            or die("fseek failed");
+            or trigger_error("GeoIP API: fseek failed", E_USER_ERROR);
             $buf = fread($gi->filehandle, 2 * $gi->record_length);
         }
         $x = array(0, 0);
@@ -1761,7 +1761,7 @@ function _geoip_seek_country($gi, $ipnum)
             $offset = $x[0];
         }
     }
-    trigger_error("error traversing database - perhaps it is corrupt?", E_USER_ERROR);
+    trigger_error("GeoIP API: Error traversing database - perhaps it is corrupt?", E_USER_ERROR);
     return false;
 }
 


### PR DESCRIPTION
Hi!

This pull request replaces all calls to `die()` with `trigger_error()` in the API functions.

IMO it’s not a good idea for an API to call `die()` as it’s catchable only via the ugly `register_shutdown_function()` which one cannot remove after the GeoIP API call. This change allows devs to gracefully handle these errors (by setting `set_error_handler`) instead of hard breaking all functionality. Let the dev instead of the API decide whether to hard break an app/website/…, to ignore the error or to show a neat message.

Additionally I’ve added a source description in front of the error messages to easier locate error messages reported by end users.

Thanks!
