### PR TITLE
remove bug if timeZone is not found, set default timeTimeZone as empty s...

### DIFF
--- a/src/timezone.php
+++ b/src/timezone.php
@@ -3,11 +3,11 @@
  * Get time zone
  * @param string $country
  * @param string $region
- * @return string If the timezone is not found, returns an empty string
+ * @return string If the timezone is not found, returns NULL
  */
 function get_time_zone($country, $region)
 {
-    $timezone = '';
+    $timezone = null;
     switch ($country) {
         case "AD":
             $timezone = "Europe/Andorra";


### PR DESCRIPTION
If timeZone is not found, there are error like: "Undefined variable: timezone in file "/var/www/20141219141026/vendor/geoip/geoip/src/timezone.php" on line "2234". 
For fix this bug, i set default timeZone as NULL. So if the timezone is not found, returns NULL.
