### PR TITLE
fix Markdown syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,7 @@ This code is tested on PHP 5.4 and greater. Older versions of PHP may work.
 
 ## Support ##
 
-For help with this API or our databases, please see [our support page]
-(http://www.maxmind.com/en/support).
+For help with this API or our databases, please see [our support page](http://www.maxmind.com/en/support).
 
 ## Copyright and License ##
 


### PR DESCRIPTION
With this change the string "our support page" will actually be used as the text for the hyperlink to the support page.